### PR TITLE
Fix core install bug & remove wp-cli dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
         "files": [ "project-command.php" ]
     },
     "require": {
-        "wp-cli/wp-cli": "^2.1.0"
     },
     "require-dev": {
         "behat/behat": "~2.5"

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     "require": {
     },
     "require-dev": {
-        "behat/behat": "~2.5"
+        "behat/behat": "~2.5",
+        "wp-cli/wp-cli": "^2.1.0"
     }
 }

--- a/inc/class-command.php
+++ b/inc/class-command.php
@@ -280,7 +280,7 @@ class Command extends WP_CLI {
 
 			WP_CLI::success( 'Starting WordPress install process...' );
 
-			$core_install = 'wp core install --url=%s --title=%s --admin_user=%s --admin_email=%s --admin_password=%s';
+			$core_install = 'core install --url=%s --title=%s --admin_user=%s --admin_email=%s --admin_password=%s';
 
 			$url      = \cli\prompt( 'Site Url' );
 			$title    = \cli\prompt( 'Site Title' );
@@ -288,7 +288,10 @@ class Command extends WP_CLI {
 			$email    = \cli\prompt( 'Admin Email' );
 			$password = \cli\prompt( 'Admin Password' );
 
-			WP_CLI::launch( WP_CLI\Utils\esc_cmd( $core_install, $url, $title, $user, $email, $password ), false, true );
+			WP_CLI::runcommand(
+				WP_CLI\Utils\esc_cmd( $core_install, $url, $title, $user, $email, $password ),
+				['exit_error' => false]
+			);
 		} else {
 			WP_CLI::success( 'WordPress appears to already be installed!' );
 		}

--- a/project-command.php
+++ b/project-command.php
@@ -3,7 +3,10 @@ if ( ! class_exists( 'WP_CLI' ) ) {
 	return;
 }
 
-require_once __DIR__ . '/vendor/autoload.php';
+$autoloader = __DIR__ . '/vendor/autoload.php';
+if ( file_exists( $autoloader ) ) {
+	require_once $autoloader;
+}
 
 spl_autoload_register(
 	function( $class ) {


### PR DESCRIPTION
Ran across two hurdles when trying to install this from scratch, so this should hopefully fix them:

**First**, there doesn't seem to be a need to have wp-cli as a dependency. When I was trying to install this on a new machine, it complained the composer packages weren't installed, so I had to manually go to the packages install directory and run composer install. Removing the wp-cli dependency works just fine and the cli uses the globally isntalled wp-cli code instead (also ran across this when trying to add debug statements into the wp-cli package code and wondering why they weren't showing up).

**Second**, I would constantly be running into errors running `wp project init` and creating the database tables from the interface.
```bash
➜  ~/test  wp project init
Desired WordPress version [latest]: 
Details: Downloading WordPress latest
Success: WordPress v already installed.
Warning: wp-config.php needs to be created.
DB_NAME: wordpress
DB_USER: wordpress
DB_PASS: wordpress
DB_PREFIX [wp_]: 
DB_HOST [localhost]: 
Warning: The database needs to be created.
Created the database from details in wp-config.php and continue? [Y/n]y
Success: Database created.
Success: Starting WordPress install process...
Site Url: test.test
Site Title: test
Admin User: test
Admin Email: asdf@qwertasdfasdasd.asd
Admin Password: asdfasd
Error: The site you have requested is not installed.
Run `wp core install` to create database tables.
➜  ~/test  
```
I believe it is related to wp-cli doing a global check at the start of every command to make sure core is installed (which is weird, because it's trying to run the `wp core install` command) (see [here](https://github.com/wp-cli/wp-cli/blob/da5e38bc6240bc8d33c5d5d646d367598045176c/php/utils-wp.php#L7), used [here](https://github.com/wp-cli/wp-cli/blob/779bdd16025cb718260b35fd2b69ae47ca80cb91/php/wp-settings-cli.php#L174) and [here](https://github.com/wp-cli/wp-cli/blob/8be8a5aca7b3176a0935f5e83b7426cfc786f13f/php/WP_CLI/Runner.php#L1360). Nevertheless, changing the code from using `WP_CLI::launch` to `WP_CLI::runcommand` seems to do the trick.